### PR TITLE
Add support for Java 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,8 +97,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
 

--- a/src/main/java/org/secnod/shiro/jersey/ShiroResourceFilterFactory.java
+++ b/src/main/java/org/secnod/shiro/jersey/ShiroResourceFilterFactory.java
@@ -27,7 +27,7 @@ public class ShiroResourceFilterFactory implements ResourceFilterFactory {
 
     @Override
     public List<ResourceFilter> create(AbstractMethod am) {
-        List<ResourceFilter> filters = new ArrayList<>();
+        List<ResourceFilter> filters = new ArrayList<ResourceFilter>();
 
         for (Class<? extends Annotation> annotationClass : shiroAnnotations) {
             // XXX What is the performance of getAnnotation vs getAnnotations?


### PR DESCRIPTION
I like coding with Java 7 more in general, but wanted to use this with a project that's still on Java 6. Seems like supporting Java 6 isn't too much of a burden given that it's only a few extra characters.
